### PR TITLE
Add call_logs resource for browser call modal persistence

### DIFF
--- a/lib/pipeline.rb
+++ b/lib/pipeline.rb
@@ -206,6 +206,10 @@ class Pipeline
   def imports
     Pipeline::Imports.new(pipeline: self)
   end
+
+  def call_logs
+    Pipeline::CallLogs.new(pipeline: self)
+  end
 end
 
 require "pipeline/base"

--- a/lib/pipeline/collection.rb
+++ b/lib/pipeline/collection.rb
@@ -88,6 +88,7 @@ Pipeline::CalendarTasks = Class.new(Pipeline::Collection)
 Pipeline::Searches = Class.new(Pipeline::Collection)
 Pipeline::Comments = Class.new(Pipeline::Collection)
 Pipeline::Imports = Class.new(Pipeline::Collection)
+Pipeline::CallLogs = Class.new(Pipeline::Collection)
 module Pipeline::Admin
   Webhooks = Class.new(Pipeline::Collection)
   Features = Class.new(Pipeline::Collection)

--- a/lib/pipeline/resource.rb
+++ b/lib/pipeline/resource.rb
@@ -108,6 +108,7 @@ Pipeline::CalendarEvent = Class.new(Pipeline::Resource)
 Pipeline::CalendarTask = Class.new(Pipeline::Resource)
 Pipeline::Search = Class.new(Pipeline::Resource)
 Pipeline::Comment = Class.new(Pipeline::Resource)
+Pipeline::CallLog = Class.new(Pipeline::Resource)
 module Pipeline::Admin
   Webhook = Class.new(Pipeline::Resource)
   PredefinedContactsTag = Class.new(Pipeline::Resource)

--- a/pipeline_api.gemspec
+++ b/pipeline_api.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "pipeline"
-  gem.version       = "1.0.7"
+  gem.version       = "1.0.8"
   gem.authors       = ["Scott Gibson"]
   gem.email         = ["sevgibson@gmail.com"]
   gem.description   = "The pipeline gem is a ruby wrapper around the Pipeline API."

--- a/spec/pipeline/call_logs_spec.rb
+++ b/spec/pipeline/call_logs_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Pipeline::CallLogs do
+  let(:pipeline) { Pipeline.new(url: "http://pld.com", jwt: { token: "test_token" }) }
+
+  describe "#new" do
+    it "creates a new CallLog instance" do
+      call_log = pipeline.call_logs.new(conference_name: "conf_123", status: "ringing")
+      expect(call_log).to be_a(Pipeline::CallLog)
+      expect(call_log.conference_name).to eq("conf_123")
+      expect(call_log.status).to eq("ringing")
+    end
+  end
+
+  # NOTE: #find tests would need VCR cassettes recorded against a running API
+
+  describe Pipeline::CallLog do
+    it "can be instantiated with attributes" do
+      call_log = described_class.new(
+        pipeline: pipeline,
+        attributes: {
+          "id" => 1,
+          "conference_name" => "conf_123",
+          "status" => "in_progress",
+          "direction" => "incoming"
+        }
+      )
+
+      expect(call_log.id).to eq(1)
+      expect(call_log.conference_name).to eq("conf_123")
+      expect(call_log.status).to eq("in_progress")
+      expect(call_log.direction).to eq("incoming")
+    end
+
+    it "tracks attribute changes from initial state" do
+      call_log = described_class.new(
+        pipeline: pipeline,
+        attributes: { "conference_name" => "conf_123", "status" => "ringing" }
+      )
+
+      # New resources track changes from nil
+      expect(call_log.changes).to include("status" => [nil, "ringing"])
+
+      call_log.status = "completed"
+      expect(call_log.changes).to include("status" => [nil, "completed"])
+    end
+  end
+end


### PR DESCRIPTION
This is necessary for p.integrations tell p.core about calls in progress and update status, etc.
p.core will be able to show the CallModal in app for advanced call controls, even if the call is handled on mobile.
p.core will be able to build a call log UI using the call_logs tables.

- Add Pipeline::CallLogs collection class
- Add Pipeline::CallLog resource class
- Add call_logs method to Pipeline client