### PR TITLE
Fix dependabot security vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # A sample Gemfile
 source "https://rubygems.org"
 
-gem 'activesupport', '~> 7.0.7.1'
+gem 'activesupport', '~> 7.2.3.1'
 gem 'httparty'
 
 group :development, :test, :ci do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,33 +1,45 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.7.2)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    activesupport (7.2.3.1)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
+      logger (>= 1.4.2)
+      minitest (>= 5.1, < 6)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    base64 (0.3.0)
+    benchmark (0.5.0)
     bigdecimal (4.0.1)
     coderay (1.1.3)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
     crack (0.4.5)
       rexml
     csv (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    drb (2.2.3)
     hashdiff (1.0.1)
     httparty (0.24.2)
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    i18n (1.14.7)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
+    logger (1.7.0)
     method_source (1.0.0)
     mini_mime (1.1.5)
-    minitest (5.25.5)
+    minitest (5.27.0)
     multi_xml (0.8.1)
       bigdecimal (>= 3.1, < 5)
     parallel (1.23.0)
@@ -76,6 +88,7 @@ GEM
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -95,7 +108,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (~> 7.0.7.1)
+  activesupport (~> 7.2.3.1)
   httparty
   pry
   rspec
@@ -107,4 +120,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.4.7
+   2.4.19


### PR DESCRIPTION
## Summary
- Update activesupport to >= 7.2.3.1 to address CVE-2026-33176, CVE-2026-33169, CVE-2026-33170
- bundle-audit check passes clean

## Test plan
- [ ] Verify bundle install succeeds
- [ ] Verify bundle-audit check passes
- [ ] Run test suite