### PR TITLE
Forward .order() value to the HTTP query (DP-56)

### DIFF
--- a/lib/pipeline/collection.rb
+++ b/lib/pipeline/collection.rb
@@ -70,6 +70,7 @@ class Pipeline::Collection < Pipeline::Base
   def read_page(page: 1, per_page: nil)
     query = { page: page, per_page: per_page }.select { |_k, v| v.present? }
     query.merge!(conditions: conditions) if conditions.present?
+    query[:sort] = sort_by if sort_by.present?
     _get("#{collection_name}.json", query: query)
   end
 end


### PR DESCRIPTION
## Summary

\`Pipeline::Collection#order(sort_by)\` stored \`@sort_by\` but \`#read_page\` never included it in the HTTP query params. So \`pipeline_api.people.where(...).order("-people.updated_at").first\` silently returned whatever the server's default ordering was — the \`.order\` call was a no-op.

One-line fix: add \`query[:sort] = sort_by if sort_by.present?\` to \`read_page\`. Pipeline CRM's API v3 list endpoints (\`/api/v3/people\`, \`/api/v3/companies\`, …) already accept this with the same \`"[-]table.column"\` format their \`DefaultSort\` constants use (e.g. \`"-people.updated_at"\`).

Callers that never set \`.order\` keep today's behavior — no \`sort\` param is sent and the server applies its own default.

## Why now

Needed for [DP-56](https://pipelinecrm.atlassian.net/browse/DP-56) — the phone/SMS integration flow's fallback finder (when the internal phone_lookup endpoint fails) uses \`pipeline_api.people.where(person_phones: …).first\`. We want it to tie-break on most-recently-updated when a number matches multiple records, which requires \`.order\` to actually work.

## Test plan

- [ ] \`people_collection.where(something).order("-people.updated_at").first\` produces an HTTP GET with \`?sort=-people.updated_at\` in the query string.
- [ ] \`people_collection.where(something).first\` (no \`.order\`) still produces a request without a \`sort\` param (existing behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)