### PR TITLE
RCR-2 Add ring_central_call_recordings resource to the pipeline API client

### DIFF
--- a/lib/pipeline.rb
+++ b/lib/pipeline.rb
@@ -71,6 +71,10 @@ class Pipeline
     Pipeline::Documents.new(pipeline: self)
   end
 
+  def ring_central_call_recordings
+    Pipeline::RingCentralCallRecordings.new(pipeline: self)
+  end
+
   def searches
     Pipeline::Searches.new(pipeline: self)
   end

--- a/lib/pipeline/collection.rb
+++ b/lib/pipeline/collection.rb
@@ -90,6 +90,14 @@ Pipeline::Searches = Class.new(Pipeline::Collection)
 Pipeline::Comments = Class.new(Pipeline::Collection)
 Pipeline::Imports = Class.new(Pipeline::Collection)
 Pipeline::CallLogs = Class.new(Pipeline::Collection)
+
+class Pipeline::RingCentralCallRecordings < Pipeline::Collection
+  # POST /api/v3/ring_central_call_recordings/:id/confirm.json
+  def confirm(id)
+    _post("#{collection_name}/#{id}/confirm.json")
+  end
+end
+
 module Pipeline::Admin
   Webhooks = Class.new(Pipeline::Collection)
   Features = Class.new(Pipeline::Collection)

--- a/lib/pipeline/resource.rb
+++ b/lib/pipeline/resource.rb
@@ -109,6 +109,7 @@ Pipeline::CalendarTask = Class.new(Pipeline::Resource)
 Pipeline::Search = Class.new(Pipeline::Resource)
 Pipeline::Comment = Class.new(Pipeline::Resource)
 Pipeline::CallLog = Class.new(Pipeline::Resource)
+Pipeline::RingCentralCallRecording = Class.new(Pipeline::Resource)
 module Pipeline::Admin
   Webhook = Class.new(Pipeline::Resource)
   PredefinedContactsTag = Class.new(Pipeline::Resource)


### PR DESCRIPTION
### Stories

- [RCR-2](https://pipelinecrm.atlassian.net/browse/RCR-2) — RingCentral call recording capture

### Notes

Adds the `ring_central_call_recordings` resource to the Pipeline API client. `pipeline_integrations` uses it to push captured RingCentral recordings into p.core via the presigned-PUT handshake.

* New `Pipeline::RingCentralCallRecording` resource + `Pipeline::RingCentralCallRecordings` collection (`create`, `confirm`) and the `ring_central_call_recordings` client accessor.
* Consumed by p.core's `Api::V3::RingCentralCallRecordingsController` — `create` returns a presigned PUT URL; `confirm` validates the upload landed.

Part of a 3-repo change for **RCR-2** (review/merge in order):

1. **this PR** — `pipeline_api` gem resource
2. p.core capture spine — https://github.com/PipelineDeals/pipeline_deals/pull/18214
3. p.integrations worker — https://github.com/PipelineDeals/pipeline_integrations/pull/395

**Design context (Notion):**

* Build plan / brief — https://www.notion.so/372eba870b26807581a3c407a9718e42
* STEP 2 (architecture) — https://www.notion.so/373eba870b2681b3988cceb89189c4b3
* ADRs — https://app.notion.com/p/375eba870b2681f88ca8dbfe9e3ce082
* STEP 3 (POC, end-to-end on a live RC account) — https://app.notion.com/p/375eba870b268141a137e7939a43c5dd

### Reviewer Checklist

- [ ] Functions as Expected
- [ ] Maintainability, Readability, Simplicity
- [ ] Test Coverage
- [ ] Security
- [ ] Performance
- [ ] Compliance with Team Standards
- [ ] Error Handling