### PR TITLE
RCR-2: call_logs recording upload + confirm methods

### DIFF
--- a/lib/pipeline/collection.rb
+++ b/lib/pipeline/collection.rb
@@ -89,7 +89,19 @@ Pipeline::CalendarTasks = Class.new(Pipeline::Collection)
 Pipeline::Searches = Class.new(Pipeline::Collection)
 Pipeline::Comments = Class.new(Pipeline::Collection)
 Pipeline::Imports = Class.new(Pipeline::Collection)
-Pipeline::CallLogs = Class.new(Pipeline::Collection)
+Pipeline::CallLogs = Class.new(Pipeline::Collection) do
+  # RCR-2 recording capture, keyed by conference_name (the shared per-call
+  # session id) rather than the p.core id, since p.int may not hold the id.
+  # Mint a presigned S3 PUT URL, then confirm once the bytes have landed.
+  def recording_upload_url(conference_name:, recording_mime: nil)
+    _post("call_logs/recording_upload_url.json",
+          body: { call_log: { conference_name: conference_name, recording_mime: recording_mime } })
+  end
+
+  def confirm_recording(conference_name:)
+    _post("call_logs/confirm_recording.json", body: { call_log: { conference_name: conference_name } })
+  end
+end
 module Pipeline::Admin
   Webhooks = Class.new(Pipeline::Collection)
   Features = Class.new(Pipeline::Collection)

--- a/spec/pipeline/call_logs_spec.rb
+++ b/spec/pipeline/call_logs_spec.rb
@@ -47,4 +47,31 @@ describe Pipeline::CallLogs do
       expect(call_log.changes).to include("status" => [nil, "completed"])
     end
   end
+
+  describe "#recording_upload_url" do
+    it "posts conference_name + mime to the recording_upload_url endpoint and returns the payload" do
+      collection = pipeline.call_logs
+      allow(collection).to receive(:_post)
+        .with("call_logs/recording_upload_url.json",
+              body: { call_log: { conference_name: "tele-1", recording_mime: "audio/mpeg" } })
+        .and_return("recording_upload_url" => "https://s3/put", "file_key" => "k")
+
+      result = collection.recording_upload_url(conference_name: "tele-1", recording_mime: "audio/mpeg")
+
+      expect(result["recording_upload_url"]).to eq("https://s3/put")
+    end
+  end
+
+  describe "#confirm_recording" do
+    it "posts the conference_name to the confirm_recording endpoint" do
+      collection = pipeline.call_logs
+      allow(collection).to receive(:_post)
+        .with("call_logs/confirm_recording.json", body: { call_log: { conference_name: "tele-1" } })
+        .and_return("recording_status" => "captured")
+
+      result = collection.confirm_recording(conference_name: "tele-1")
+
+      expect(result["recording_status"]).to eq("captured")
+    end
+  end
 end


### PR DESCRIPTION
Part of **RCR-2** (RingCentral + Twilio call-recording capture).

Adds the `call_logs` methods the integrations service uses for the recording handshake:
- `Pipeline::CallLogs#recording_upload_url` (mint presigned S3 PUT, keyed by `conference_name`)
- `Pipeline::CallLogs#confirm_recording`

**Supersedes** the dropped RC-specific resource in #37 (not needed — reuses `call_logs`).

**Merge order:** this gem PR first → p.core → p.int (p.int re-pins its Gemfile to this gem once merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
