### PR TITLE
Add Pipeline#get for authenticated custom-endpoint requests

### DIFF
--- a/lib/pipeline.rb
+++ b/lib/pipeline.rb
@@ -210,6 +210,14 @@ class Pipeline
   def call_logs
     Pipeline::CallLogs.new(pipeline: self)
   end
+
+  # Query a p.core endpoint outside the standard /api/v3 resource prefix
+  # (e.g. "/api/internal/phone_lookup"), reusing this client's authentication
+  # and error handling. `path` is relative to the host root.
+  def get(path, query: {}, headers: {})
+    Pipeline::Endpoint.new(pipeline: self).get(path, query: query, headers: headers)
+  end
 end
 
 require "pipeline/base"
+require "pipeline/endpoint"

--- a/lib/pipeline/endpoint.rb
+++ b/lib/pipeline/endpoint.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "pipeline/base"
+
+# Generic accessor for p.core endpoints the typed resource classes don't cover —
+# notably internal endpoints outside the /api/v3 prefix (e.g.
+# /api/internal/phone_lookup). Reuses Base's authentication (common_query /
+# common_headers) and error handling so callers don't reimplement them. `path`
+# is taken relative to the host root, not the /api/v3 prefix.
+class Pipeline::Endpoint < Pipeline::Base
+  def get(path, query: {}, headers: {})
+    handle_errors(HTTParty.get("#{pipeline.url}#{path}", query: query.merge(common_query), headers: headers.merge(common_headers)))
+  end
+end

--- a/pipeline_api.gemspec
+++ b/pipeline_api.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "pipeline"
-  gem.version       = "1.0.9"
+  gem.version       = "1.0.10"
   gem.authors       = ["Scott Gibson"]
   gem.email         = ["sevgibson@gmail.com"]
   gem.description   = "The pipeline gem is a ruby wrapper around the Pipeline API."

--- a/spec/pipeline/endpoint_spec.rb
+++ b/spec/pipeline/endpoint_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "webmock/rspec"
+
+describe Pipeline::Endpoint do
+  let(:pipeline) { Pipeline.new(url: "http://pld.com", jwt: { token: "jwt-token" }) }
+
+  it "GETs a path outside the /api/v3 prefix, authenticated, and returns the parsed body" do
+    stub = stub_request(:get, "http://pld.com/api/internal/phone_lookup")
+           .with(query: { "phone" => "+15551234567" }, headers: { "Authorization" => "Bearer jwt-token" })
+           .to_return(status: 200, body: { "people" => [{ "id" => 1 }] }.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = pipeline.get("/api/internal/phone_lookup", query: { phone: "+15551234567" })
+
+    expect(result["people"].first["id"]).to eq(1)
+    expect(stub).to have_been_requested
+  end
+
+  it "authenticates with key params when there is no jwt" do
+    pipeline = Pipeline.new(url: "http://pld.com", app_key: "app-key", account_key: "account-key")
+    stub = stub_request(:get, "http://pld.com/api/internal/phone_lookup")
+           .with(query: { "app_key" => "app-key", "account_key" => "account-key" })
+           .to_return(status: 200, body: { "companies" => [] }.to_json)
+
+    pipeline.get("/api/internal/phone_lookup")
+
+    expect(stub).to have_been_requested
+  end
+
+  it "raises on a non-success response" do
+    stub_request(:get, "http://pld.com/api/internal/phone_lookup").to_return(status: 401, body: { "error" => "nope" }.to_json)
+
+    expect { pipeline.get("/api/internal/phone_lookup") }.to raise_error(Pipeline::Exceptions::NotAuthorizedError)
+  end
+end

--- a/spec/pipeline/endpoint_spec.rb
+++ b/spec/pipeline/endpoint_spec.rb
@@ -8,8 +8,8 @@ describe Pipeline::Endpoint do
 
   it "GETs a path outside the /api/v3 prefix, authenticated, and returns the parsed body" do
     stub = stub_request(:get, "http://pld.com/api/internal/phone_lookup")
-           .with(query: { "phone" => "+15551234567" }, headers: { "Authorization" => "Bearer jwt-token" })
-           .to_return(status: 200, body: { "people" => [{ "id" => 1 }] }.to_json, headers: { "Content-Type" => "application/json" })
+      .with(query: { "phone" => "+15551234567" }, headers: { "Authorization" => "Bearer jwt-token" })
+      .to_return(status: 200, body: { "people" => [{ "id" => 1 }] }.to_json, headers: { "Content-Type" => "application/json" })
 
     result = pipeline.get("/api/internal/phone_lookup", query: { phone: "+15551234567" })
 
@@ -20,8 +20,8 @@ describe Pipeline::Endpoint do
   it "authenticates with key params when there is no jwt" do
     pipeline = Pipeline.new(url: "http://pld.com", app_key: "app-key", account_key: "account-key")
     stub = stub_request(:get, "http://pld.com/api/internal/phone_lookup")
-           .with(query: { "app_key" => "app-key", "account_key" => "account-key" })
-           .to_return(status: 200, body: { "companies" => [] }.to_json)
+      .with(query: { "app_key" => "app-key", "account_key" => "account-key" })
+      .to_return(status: 200, body: { "companies" => [] }.to_json)
 
     pipeline.get("/api/internal/phone_lookup")
 


### PR DESCRIPTION
## Overview

- We already have this call to p.core /api/internal (hardcoded using HTTP get in p.int)
- We are changing (in p.int) what JWT key we use to make the call
- I would rather use `pipeline_api_for_user(user_id).get("/api/internal/...")` instead of hardcoded HTTP get in p.int.
- So, without adding actual call for anything internal, I'm adding a get that can let us specify the url path.

## What

Adds `Pipeline#get(path, query:, headers:)` — a generic, authenticated GET against a host-relative p.core path.

The typed resource classes (`people`, `companies`, …) only cover `/api/v3` resources. Internal endpoints outside that prefix — e.g. `/api/internal/phone_lookup` — currently force callers to reimplement the host, auth headers, and error handling with a raw `HTTParty` call. This gives them a first-class method that reuses `Base`'s `common_query` / `common_headers` (so it runs as the same identity — JWT or key params) and `handle_errors`.

```ruby
pipeline.get("/api/internal/phone_lookup", query: { phone: "+15551234567" })
```

## Why

Pipeline CRM's phone integrations need to call `/api/internal/phone_lookup` as the **calling user** (per-user JWT). Centralizing the custom-endpoint call here means p.integrations' `PhoneLookup` no longer hand-rolls auth headers — it just asks the client.

## Notes

- `path` is relative to the host root (not the `/api/v3` prefix).
- Bumps gem version 1.0.9 → 1.0.10.
- Spec uses WebMock (VCR's backing hook) since there's no live endpoint to record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)