### PR TITLE
Add per-call prefix: override to HTTP verb helpers

### DIFF
--- a/lib/pipeline/base.rb
+++ b/lib/pipeline/base.rb
@@ -14,28 +14,31 @@ class Pipeline::Base
     @module_name = self.class.name.sub(/::#{collection_name.singularize.camelize}$/, "").sub(/::#{collection_name.camelize}$/, "")
   end
 
-  def _post(endpoint, query: {}, body: {}, headers: {})
-    handle_errors(HTTParty.post(full_endpoint(endpoint), query: query.merge(common_query), body: body.to_json, headers: headers.merge(common_headers)))
+  def _post(endpoint, query: {}, body: {}, headers: {}, prefix: nil)
+    handle_errors(HTTParty.post(full_endpoint(endpoint, prefix: prefix), query: query.merge(common_query), body: body.to_json, headers: headers.merge(common_headers)))
   end
 
-  def _get(endpoint, query: {}, headers: {})
-    handle_errors(HTTParty.get(full_endpoint(endpoint), query: query.merge(common_query), headers: headers.merge(common_headers)))
+  def _get(endpoint, query: {}, headers: {}, prefix: nil)
+    handle_errors(HTTParty.get(full_endpoint(endpoint, prefix: prefix), query: query.merge(common_query), headers: headers.merge(common_headers)))
   end
 
-  def _put(endpoint, query: {}, body: {}, headers: {})
-    handle_errors(HTTParty.put(full_endpoint(endpoint), query: query.merge(common_query), body: body.to_json, headers: headers.merge(common_headers)))
+  def _put(endpoint, query: {}, body: {}, headers: {}, prefix: nil)
+    handle_errors(HTTParty.put(full_endpoint(endpoint, prefix: prefix), query: query.merge(common_query), body: body.to_json, headers: headers.merge(common_headers)))
   end
 
-  def _patch(endpoint, query: {}, body: {}, headers: {})
-    handle_errors(HTTParty.patch(full_endpoint(endpoint), query: query.merge(common_query), body: body.to_json, headers: headers.merge(common_headers)))
+  def _patch(endpoint, query: {}, body: {}, headers: {}, prefix: nil)
+    handle_errors(HTTParty.patch(full_endpoint(endpoint, prefix: prefix), query: query.merge(common_query), body: body.to_json, headers: headers.merge(common_headers)))
   end
 
-  def _delete(endpoint, query: {}, headers: {})
-    handle_errors(HTTParty.delete(full_endpoint(endpoint), query: query.merge(common_query), headers: headers.merge(common_headers)))
+  def _delete(endpoint, query: {}, headers: {}, prefix: nil)
+    handle_errors(HTTParty.delete(full_endpoint(endpoint, prefix: prefix), query: query.merge(common_query), headers: headers.merge(common_headers)))
   end
 
-  def full_endpoint(endpoint)
-    "#{pipeline.url}#{pipeline.prefix}#{admin}/#{endpoint}"
+  # `prefix:` overrides pipeline.prefix for callers that need to reach a
+  # different mount point on p.core than the default /api/v3 (e.g.,
+  # engine-only endpoints mounted under a sibling namespace).
+  def full_endpoint(endpoint, prefix: nil)
+    "#{pipeline.url}#{prefix || pipeline.prefix}#{admin}/#{endpoint}"
   end
 
   def common_query

--- a/lib/pipeline/base.rb
+++ b/lib/pipeline/base.rb
@@ -15,7 +15,8 @@ class Pipeline::Base
   end
 
   def _post(endpoint, query: {}, body: {}, headers: {}, prefix: nil)
-    handle_errors(HTTParty.post(full_endpoint(endpoint, prefix: prefix), query: query.merge(common_query), body: body.to_json, headers: headers.merge(common_headers)))
+    handle_errors(HTTParty.post(full_endpoint(endpoint, prefix: prefix),
+                                query: query.merge(common_query), body: body.to_json, headers: headers.merge(common_headers)))
   end
 
   def _get(endpoint, query: {}, headers: {}, prefix: nil)
@@ -23,11 +24,13 @@ class Pipeline::Base
   end
 
   def _put(endpoint, query: {}, body: {}, headers: {}, prefix: nil)
-    handle_errors(HTTParty.put(full_endpoint(endpoint, prefix: prefix), query: query.merge(common_query), body: body.to_json, headers: headers.merge(common_headers)))
+    handle_errors(HTTParty.put(full_endpoint(endpoint, prefix: prefix),
+                               query: query.merge(common_query), body: body.to_json, headers: headers.merge(common_headers)))
   end
 
   def _patch(endpoint, query: {}, body: {}, headers: {}, prefix: nil)
-    handle_errors(HTTParty.patch(full_endpoint(endpoint, prefix: prefix), query: query.merge(common_query), body: body.to_json, headers: headers.merge(common_headers)))
+    handle_errors(HTTParty.patch(full_endpoint(endpoint, prefix: prefix),
+                                 query: query.merge(common_query), body: body.to_json, headers: headers.merge(common_headers)))
   end
 
   def _delete(endpoint, query: {}, headers: {}, prefix: nil)

--- a/pipeline_api.gemspec
+++ b/pipeline_api.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = "pipeline"
-  gem.version       = "1.0.10"
+  gem.version       = "1.0.11"
   gem.authors       = ["Scott Gibson"]
   gem.email         = ["sevgibson@gmail.com"]
   gem.description   = "The pipeline gem is a ruby wrapper around the Pipeline API."


### PR DESCRIPTION
Callers that need to hit a p.core mount point other than the default \`namespace :v3\` can now pass \`prefix: "/api/…"\` to \`_post\` / \`_get\` / \`_put\` / \`_patch\` / \`_delete\`. The override flows through \`full_endpoint\`; unchanged callers keep using \`pipeline.prefix\`.

## Motivating case

p.int's \`PipelineBillingApi#create_phone_recharge\` posts to \`/api/internal/billing/pipeline_phone_recharge\` — a route mounted under p.core's sibling \`namespace :internal\` (not \`namespace :v3\`). Before this PR, there was no way to reach that path via the gem, so the auto-recharge caller had been silently 404-ing (DP-96). Paired p.int PR: [PipelineDeals/pipeline_integrations#…](https://github.com/PipelineDeals/pipeline_integrations/pulls?q=DP-96a-pint-recharge-caller).

## Shape

\`\`\`ruby
# before
_post("billing/foo", body: {...})
# after (default unchanged)
_post("billing/foo", body: {...})
# NEW — reach a sibling mount point
_post("billing/foo", body: {...}, prefix: "/api/internal")
\`\`\`

Chose per-call \`prefix:\` over a new \`Pipeline::Internal::\` namespace class per the "don't leak an 'internal' concept into the gem's public shape" preference — the caller signals "this hits a non-default mount point" without the gem exposing what mounts exist.

## Test plan

- [ ] Existing gem specs still pass (kwarg is optional; \`prefix: nil\` preserves the previous \`pipeline.prefix\` behavior).
- [ ] p.int's \`pipeline_billing_api_spec\` asserts the new \`prefix:\` kwarg on the recharge call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)