### PR TITLE
Add committed Claude Code agent config (permissions + sensitive-file hook)

### DIFF
--- a/.claude/hooks/protect-sensitive-files.sh
+++ b/.claude/hooks/protect-sensitive-files.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# protect-sensitive-files.sh
+#
+# PreToolUse hook — blocks edits to sensitive files.
+# Receives JSON on stdin with tool_input.file_path.
+# Exit 0 = allow, Exit 2 = block (stderr shown to Claude).
+
+input=$(cat)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$file_path" ]; then
+  exit 0
+fi
+
+basename=$(basename "$file_path")
+dirpath=$(dirname "$file_path")
+
+# Block sensitive files
+case "$basename" in
+  .env|.env.*|.env.local|.env.production|.env.staging)
+    echo "BLOCKED: Will not edit environment file: $file_path" >&2
+    exit 2
+    ;;
+  credentials.json|secrets.json|secrets.yml|secrets.yaml)
+    echo "BLOCKED: Will not edit credentials file: $file_path" >&2
+    exit 2
+    ;;
+  *.pem|*.key|*.p12|*.pfx|id_rsa|id_ed25519)
+    echo "BLOCKED: Will not edit key/certificate file: $file_path" >&2
+    exit 2
+    ;;
+  master.key|credentials.yml.enc)
+    echo "BLOCKED: Will not edit Rails encrypted credentials: $file_path" >&2
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,12 @@
       "Bash(git log:*)",
       "Bash(git fetch:*)",
       "Bash(gh pr view:*)",
-      "Bash(gh pr list:*)"
+      "Bash(gh pr list:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr edit:*)",
+      "Bash(gh pr comment:*)",
+      "Bash(gh issue comment:*)"
     ],
     "deny": [
       "Read(./.env)",
@@ -25,7 +30,6 @@
       "Edit(./config/master.key)"
     ],
     "ask": [
-      "Bash(git push:*)",
       "Bash(gh pr merge:*)"
     ]
   },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,45 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bundle exec rspec:*)",
+      "Bash(bundle exec rubocop:*)",
+      "Bash(bundle exec ./script/dirty_cop:*)",
+      "Bash(git status)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git fetch:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)"
+    ],
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./config/master.key)",
+      "Read(./config/credentials/**)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Read(**/*.p12)",
+      "Read(**/id_rsa)",
+      "Edit(./.env)",
+      "Edit(./.env.*)",
+      "Edit(./config/master.key)"
+    ],
+    "ask": [
+      "Bash(git push:*)",
+      "Bash(gh pr merge:*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/protect-sensitive-files.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+
+# Personal Claude Code config (the shared config in .claude/settings.json IS committed)
+.claude/settings.local.json


### PR DESCRIPTION
This commits the team-shared Claude Code agent configuration as part of the agentic-readiness work:

* **`.claude/settings.json`** — the shared permission baseline:
  * **deny**: reads/edits of secrets (`.env*`, `config/master.key`, `config/credentials/**`, `*.pem`/`*.key`/`*.p12`, `id_rsa`)
  * **ask**: prompts before high-risk actions (`git push`, `gh pr merge`)
  * **allow**: only what this repo actually runs — RSpec, RuboCop, and `./script/dirty_cop` (matches CircleCI). This repo is a gem with no database, so the Rails `db:migrate`/`db:rollback` ask rules are omitted — plus read-only `git`/`gh` commands
* **`.claude/hooks/protect-sensitive-files.sh`** — a PreToolUse guard that blocks Edit/Write on env files, credentials, and key/certificate files as a second layer behind the permission rules.
* `.gitignore` now ignores `.claude/settings.local.json` — personal per-developer configs extend this shared baseline locally and never get committed.

No application code changes; config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Update: agents may push branches and create/edit PRs without prompts; merge and migrations remain human-gated (and branch protection requires human approval regardless).