### PR TITLE
Run Claude review automatically on every PR

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -72,4 +72,4 @@ jobs:
             manufacture findings. Reserve detailed comments for real issues.
           track_progress: true
           include_fix_links: true
-          claude_args: "--max-turns 12 --max-budget-usd 0.75"
+          claude_args: "--model claude-sonnet-5 --max-turns 12 --max-budget-usd 0.75"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,75 @@
+# Claude auto-review: runs on every non-draft PR when opened or marked ready
+# for review; mention @claude in a PR comment to trigger a re-review.
+# Requires the org-level ANTHROPIC_API_KEY secret.
+name: Claude Code
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  actions: read
+  id-token: write
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Acknowledge comment
+        # Only comment events carry github.event.comment; skip on pull_request
+        if: github.event_name != 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName === 'pull_request_review_comment') {
+              await github.rest.reactions.createForPullRequestReviewComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'eyes'
+              });
+            } else {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'eyes'
+              });
+            }
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Review this PR for the Pipeline CRM Ruby API client gem (a wrapper
+            around the Pipeline CRM API). Focus on:
+            - Bugs or logic errors
+            - Public API changes that would break existing gem consumers
+              (renamed methods, changed signatures or return shapes)
+            - Performance: HTTP calls inside loops, missing pagination when
+              iterating API collections
+            - Convention violations per this repo's CLAUDE.md, if present
+            - Test coverage for behavioral changes
+
+            You have full repo access. Read any files you need to verify your findings.
+            Only flag issues introduced by this PR, not pre-existing patterns.
+            Be concise. If the code is sound, say so in 2-3 sentences — do not
+            manufacture findings. Reserve detailed comments for real issues.
+          track_progress: true
+          include_fix_links: true
+          claude_args: "--max-turns 12 --max-budget-usd 0.75"


### PR DESCRIPTION
Adds `.github/workflows/claude-review.yml` so Claude reviews every PR automatically.

- Auto-review triggers when a PR is opened or marked ready for review; draft PRs are excluded
- Mention `@claude` in a PR comment to trigger a re-review
- Uses the org-level `ANTHROPIC_API_KEY` secret (already visible to this repo)
- Review prompt is adapted for an API client gem: bugs, breaking public-API changes, HTTP-in-loops, CLAUDE.md conventions, test coverage (tenant-isolation/Sidekiq checks dropped since they do not apply)
- Each run is capped at 12 turns / $0.75

Part of the agentic-readiness work across Pipeline CRM Ruby repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Update: review runs pinned to Sonnet — cheaper per run, and the reviewing model differs from the model that authors most changes.