### PR TITLE
Fleet v2: reusable review shim + config alignment

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,7 +27,21 @@
       "Read(**/id_rsa)",
       "Edit(./.env)",
       "Edit(./.env.*)",
-      "Edit(./config/master.key)"
+      "Edit(./config/master.key)",
+      "Read(**/id_ed25519)",
+      "Edit(**/id_ed25519)",
+      "Read(**/*.pfx)",
+      "Edit(**/*.pfx)",
+      "Read(**/credentials.json)",
+      "Edit(**/credentials.json)",
+      "Read(**/secrets.json)",
+      "Edit(**/secrets.json)",
+      "Read(**/secrets.yml)",
+      "Edit(**/secrets.yml)",
+      "Read(**/secrets.yaml)",
+      "Edit(**/secrets.yaml)",
+      "Read(**/credentials.yml.enc)",
+      "Edit(**/credentials.yml.enc)"
     ],
     "ask": [
       "Bash(gh pr merge:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,75 +1,46 @@
-# Claude auto-review: runs on every non-draft PR when opened or marked ready
-# for review; mention @claude in a PR comment to trigger a re-review.
-# Requires the org-level ANTHROPIC_API_KEY secret.
 name: Claude Code
+
+# Thin shim — review logic lives in the org-wide reusable workflow
+# (pipeline_deals/.github/workflows/claude-review-reusable.yml).
+# This file owns only: triggers, concurrency, and the repo-specific prompt.
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, synchronize]
   issue_comment:
     types: [created]
   pull_request_review_comment:
     types: [created]
 
+# One run at a time per PR (queued, never cancelled).
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   pull-requests: write
   issues: write
+  statuses: write
   actions: read
   id-token: write
 
 jobs:
   claude:
-    if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Acknowledge comment
-        # Only comment events carry github.event.comment; skip on pull_request
-        if: github.event_name != 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            if (context.eventName === 'pull_request_review_comment') {
-              await github.rest.reactions.createForPullRequestReviewComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: context.payload.comment.id,
-                content: 'eyes'
-              });
-            } else {
-              await github.rest.reactions.createForIssueComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: context.payload.comment.id,
-                content: 'eyes'
-              });
-            }
-      - uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          prompt: |
-            Review this PR for the Pipeline CRM Ruby API client gem (a wrapper
-            around the Pipeline CRM API). Focus on:
-            - Bugs or logic errors
-            - Public API changes that would break existing gem consumers
-              (renamed methods, changed signatures or return shapes)
-            - Performance: HTTP calls inside loops, missing pagination when
-              iterating API collections
-            - Convention violations per this repo's CLAUDE.md, if present
-            - Test coverage for behavioral changes
+    uses: PipelineDeals/pipeline_deals/.github/workflows/claude-review-reusable.yml@master
+    secrets: inherit
+    # Caps inherit the reusable's defaults (30 turns / $1.50 / Sonnet).
+    with:
+      prompt: |
+        Review this PR for the Pipeline CRM Ruby API client gem (a wrapper
+        around the Pipeline CRM API). Focus on:
+        - Bugs or logic errors
+        - Public API changes that would break existing gem consumers
+          (renamed methods, changed signatures or return shapes)
+        - Performance: HTTP calls inside loops, missing pagination when
+          iterating API collections
+        - Convention violations per this repo's CLAUDE.md, if present
+        - Test coverage for behavioral changes
 
-            You have full repo access. Read any files you need to verify your findings.
-            Only flag issues introduced by this PR, not pre-existing patterns.
-            Be concise. If the code is sound, say so in 2-3 sentences — do not
-            manufacture findings. Reserve detailed comments for real issues.
-          track_progress: true
-          include_fix_links: true
-          claude_args: "--model claude-sonnet-5 --max-turns 12 --max-budget-usd 0.75"
+        You have full repo access. Read any files you need to verify your findings.
+        Only flag issues introduced by this PR, not pre-existing patterns.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# CLAUDE.md
+# AGENTS.md
 
 Context file for agents and developers working in this repo.
 


### PR DESCRIPTION
Converts this repo's Claude review workflow to a thin shim over the org-wide reusable workflow (`PipelineDeals/pipeline_deals/.github/workflows/claude-review-reusable.yml`).

- **Reusable review shim**: the shim owns only triggers, concurrency, and the repo-specific prompt. Review logic, caps, and generic guidance live in the reusable, so fleet-wide fixes become one PR to pipeline_deals while this repo keeps its own prompt.
- **AGENTS.md header**: fixed the `# CLAUDE.md` heading left over from the rename.
- **Read-deny alignment**: extended `permissions.deny` in `.claude/settings.json` so Read is blocked for the same secret-file patterns the guard hook already Edit-blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
