### PR TITLE
Bump concurrent-ruby to 1.3.8 (fixes 3 Dependabot advisories)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
     benchmark (0.5.0)
     bigdecimal (4.0.1)
     coderay (1.1.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
     crack (0.4.5)
       rexml


### PR DESCRIPTION
Transitive dep via activesupport. Clears GHSA-h8w8-99g7-qmvj (high), GHSA-wv3x-4vxv-whpp, GHSA-6wx8-w4f5-wwcr — all patched in 1.3.7.

Lockfile-only change (`concurrent-ruby 1.3.6 → 1.3.8`); full suite green (96 examples, 0 failures).

Closes #43