### PR TITLE
Add security GHA shim (gitleaks + Dependabot SLA gate)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,23 @@
+name: Security
+
+# Thin shim — gitleaks + the dependency SLA gate live in the org-wide reusable
+# workflow (pipeline_deals/.github/workflows/security-reusable.yml). This file
+# owns only triggers + concurrency; behavior inherits the reusable's defaults.
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize, reopened]
+
+# Superseding pushes cancel in-flight scans (a cancelled scan leaves no
+# misleading state — the newer commit re-scans).
+concurrency:
+  group: security-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  security:
+    uses: PipelineDeals/pipeline_deals/.github/workflows/security-reusable.yml@master
+    secrets: inherit


### PR DESCRIPTION
Fleet rollout of the shared security gate (pipeline_deals #18557 / #18559). Thin shim calling the org-wide reusable `security-reusable.yml`.

- **gitleaks** — secret-scans the PR diff.
- **dependency-audit** — Dependabot-alert SLA gate: blocks only once an alert is past its remediation SLA (crit/high 30d, med 60d, low 90d), all ecosystems; fail-closed via the org App token.

After merge + green, `security / gitleaks` + `security / dependency-audit` get added to required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)